### PR TITLE
Ethan/sprint 28/parse fix 2

### DIFF
--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -112,7 +112,13 @@ class FreshnessDateDataParser:
             ):
                 date = date.replace(tzinfo=None)
 
-        self.now = None
+        # self.now = None
+        # This ^ causes issues with threading.
+        # Issue:
+        # https://github.com/scrapinghub/dateparser/issues/276#issuecomment-290427553
+
+        # Commit, with someone else also removing this reset
+        # https://github.com/mistio/dateparser/commit/7bfc3f4ab6e7c6255ecbed9011078c07a63700ef
         return date, period
 
     def _parse_date(self, date_string, prefer_dates_from):

--- a/dateparser/freshness_date_parser.py
+++ b/dateparser/freshness_date_parser.py
@@ -113,7 +113,11 @@ class FreshnessDateDataParser:
                 date = date.replace(tzinfo=None)
 
         # self.now = None
+
         # This ^ causes issues with threading.
+        # I think we're OK to take this "reset" out here.
+        # self.now = None gets set in the init of this class.
+
         # Issue:
         # https://github.com/scrapinghub/dateparser/issues/276#issuecomment-290427553
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,13 @@
 import re
 from setuptools import setup, find_packages
 
-__version__ = re.search(r"__version__.*\s*=\s*[']([^']+)[']", open('dateparser/__init__.py').read()).group(1)
-
-introduction = re.sub(r':members:.+|..\sautomodule::.+|:class:|:func:|:ref:', '', open('docs/introduction.rst').read())
-history = re.sub(r':mod:|:class:|:func:', '', open('HISTORY.rst').read())
-
-test_requirements = open('tests/requirements.txt').read().splitlines()
+__version__ = "1.0.0-el5"
 
 setup(
     name='dateparser',
     version=__version__,
     description='Date parsing library designed to parse dates from HTML pages',
-    long_description=introduction + '\n\n' + history,
+    long_description="forked to fix threading issue",
     author='Scrapinghub',
     author_email='info@scrapinghub.com',
     url='https://github.com/scrapinghub/dateparser',

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 import re
 from setuptools import setup, find_packages
 
-__version__ = "1.0.0-el5"
+__version__ = re.search(r"__version__.*\s*=\s*[']([^']+)[']", open('dateparser/__init__.py').read()).group(1)
+
+introduction = re.sub(r':members:.+|..\sautomodule::.+|:class:|:func:|:ref:', '', open('docs/introduction.rst').read())
+history = re.sub(r':mod:|:class:|:func:', '', open('HISTORY.rst').read())
+
+test_requirements = open('tests/requirements.txt').read().splitlines()
 
 setup(
     name='dateparser',
-    version=__version__,
+    version="1.0.0-vklabs1",
     description='Date parsing library designed to parse dates from HTML pages',
-    long_description="forked to fix threading issue",
+    long_description=introduction + '\n\n' + history,
     author='Scrapinghub',
     author_email='info@scrapinghub.com',
     url='https://github.com/scrapinghub/dateparser',


### PR DESCRIPTION
remove the line that breaks this library in threaded apps. 

Tested this locally, and dates were parsed as expected (7 days ago, 90 days ago, etc). The line we removed does not appear to matter in our use case. 

self.now gets reset in the init of the class, and is set in other places in the function that we are using

I threw my initials on the version number, but i imagine we'll want something more formal, and i don't want to accidentally publish this the wrong way again. @wmarshall can we chat about this? thx